### PR TITLE
Fix lint errors

### DIFF
--- a/pkn/importer/lazy.py
+++ b/pkn/importer/lazy.py
@@ -1,10 +1,9 @@
 import importlib
-from typing import Dict, List
 
 __all__ = ("make_lazy_getattr",)
 
 
-def make_lazy_getattr(package, module_map: Dict[str, List[str]]):
+def make_lazy_getattr(package, module_map: dict[str, list[str]]):
     # build a reverse index mapping
     mapping = {}
     for mod, subs in module_map.items():

--- a/pkn/logging/__init__.py
+++ b/pkn/logging/__init__.py
@@ -4,13 +4,13 @@ from inspect import currentframe
 from logging import FileHandler as BaseFileHandler, Formatter, Logger, StreamHandler, getLogger as baseGetLogger
 from logging.config import dictConfig
 from pathlib import Path
-from typing import Literal, Optional, Union
+from typing import Literal
 
-__all__ = ("default", "getLogger", "getSimpleLogger", "StreamHandler", "FileHandler")
+__all__ = ("FileHandler", "StreamHandler", "default", "getLogger", "getSimpleLogger")
 
 LogLevelStr = Literal["CRITICAL", "FATAL", "ERROR", "WARNING", "WARN", "INFO", "DEBUG", "NOTSET"]
 LogLevelInt = Literal[50, 40, 30, 20, 10, 0]
-LogLevel = Union[LogLevelStr, LogLevelInt]
+LogLevel = LogLevelStr | LogLevelInt
 
 
 class FileHandler(BaseFileHandler):
@@ -24,10 +24,10 @@ def default(
     console_level: LogLevel = "INFO",
     file_level: LogLevel = "DEBUG",
 ) -> None:
-    config = dict(
-        version=1,
-        disable_existing_loggers=False,
-        formatters={
+    config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
             "simple": {"format": "[%(asctime)s][%(threadName)s][%(name)s][%(levelname)s]: %(message)s"},
             "colorlog": {
                 "()": "colorlog.ColoredFormatter",
@@ -42,11 +42,11 @@ def default(
             },
             "whenAndWhere": {"format": "[%(asctime)s][%(threadName)s][%(name)s][%(filename)s:%(lineno)d][%(levelname)s]: %(message)s"},
         },
-        handlers={
+        "handlers": {
             "console": {"level": console_level, "class": "pkn.logging.StreamHandler", "formatter": "colorlog", "stream": "ext://sys.stdout"},
         },
-        root={"handlers": ["console"], "level": "DEBUG"},
-    )
+        "root": {"handlers": ["console"], "level": "DEBUG"},
+    }
     if file:
         config["handlers"]["file"] = {"level": file_level, "class": "pkn.logging.FileHandler", "formatter": "whenAndWhere", "filename": file}
     dictConfig(config)
@@ -67,7 +67,7 @@ def getLogger() -> Logger:
     return baseGetLogger(module_name)
 
 
-def getSimpleLogger(name: str, file: Optional[str] = None, stdout: bool = False) -> Logger:
+def getSimpleLogger(name: str, file: str | None = None, stdout: bool = False) -> Logger:
     log = baseGetLogger(name)
     handler = StreamHandler(stream=sys.stdout if stdout else sys.stderr)
     formatter = Formatter("[%(asctime)s][%(name)s][%(levelname)s]: %(message)s", datefmt="%Y-%m-%dT%H:%M:%S%z")

--- a/pkn/pydantic/paths.py
+++ b/pkn/pydantic/paths.py
@@ -1,21 +1,19 @@
 from importlib import import_module
 from types import FunctionType, MethodType
-from typing import Annotated, Optional
+from typing import Annotated
 
 from pydantic import BeforeValidator, PlainSerializer
 
 __all__ = (
+    "CallablePath",
+    "ImportPath",
     "get_import_path",
     "serialize_path_as_string",
-    "ImportPath",
-    "CallablePath",
 )
 
 
 def get_import_path(path: str) -> type:
-    if isinstance(path, type):
-        return path
-    elif isinstance(path, (FunctionType, MethodType)):
+    if isinstance(path, (type, FunctionType, MethodType)):
         return path
     if not isinstance(path, str):
         raise TypeError(path)
@@ -23,7 +21,7 @@ def get_import_path(path: str) -> type:
     return getattr(import_module(module), call)
 
 
-def serialize_path_as_string(value: type) -> Optional[str]:
+def serialize_path_as_string(value: type) -> str | None:
     if value is None:
         return None
     if hasattr(value, "__module__") and hasattr(value, "__qualname__"):

--- a/pkn/pydantic/roots.py
+++ b/pkn/pydantic/roots.py
@@ -1,4 +1,4 @@
-from typing import Dict as DictType, List as ListType, Optional, Union
+from typing import Union
 
 from pydantic import BaseModel, Field, RootModel
 
@@ -6,7 +6,7 @@ __all__ = ("Dict", "List")
 
 
 class Dict(RootModel):
-    root: Optional[DictType[str, Optional[Union[BaseModel, "Dict", "List", int, float, str]]]] = Field(default_factory=dict)
+    root: dict[str, Union[BaseModel, "Dict", "List", int, float, str] | None] | None = Field(default_factory=dict)
 
     def __iter__(self):
         return iter(self.root)
@@ -46,7 +46,7 @@ class Dict(RootModel):
 
 
 class List(RootModel):
-    root: Optional[ListType[Union[BaseModel, "Dict", "List", int, float, str]]] = Field(default_factory=list)
+    root: list[Union[BaseModel, "Dict", "List", int, float, str]] | None = Field(default_factory=list)
 
     def __iter__(self):
         return iter(self.root)
@@ -69,7 +69,7 @@ class List(RootModel):
     def append(self, value: BaseModel):
         self.root.append(value)
 
-    def extend(self, values: ListType[BaseModel]):
+    def extend(self, values: list[BaseModel]):
         self.root.extend(values)
 
     def insert(self, index: int, value: BaseModel):


### PR DESCRIPTION
Updates code for the latest Ruff diagnostics without changing lint configuration. `make lint` passes.